### PR TITLE
Correction erreur Gulp

### DIFF
--- a/Liste/V0/gulpfile.js
+++ b/Liste/V0/gulpfile.js
@@ -12,7 +12,7 @@ var gulp				= require('gulp')
   , upath				= require("upath")
   ;
 
-var webpackEntries	=	[ 'js/secretary.js'
+var webpackEntries	=	[ './mainV0.js'
 						]
 var filesToLint 	=	[ 'js/**/*.js'
 						, 'serverCabinetMedical.js'

--- a/Liste/V0/mainV0.js
+++ b/Liste/V0/mainV0.js
@@ -1,11 +1,11 @@
 // Framework Angular
 var angular 			= require( "angular" 					)
-  , angular-material	= require( "angular-material" 			)
-  , angular-aria 		= require( "angular-aria" 				)
-  , angular-animate		= require( "angular-animate" 			)
+  , angularMaterial	= require( "angular-material" 			)
+  , angularAria 		= require( "angular-aria" 				)
+  , angularAnimate		= require( "angular-animate" 			)
   ;
 
 
-var mod = angualar.module( "bshm", ["angular-material"] );
+var mod = angular.module( "bshm", ["angular-material"] );
 
-require( "./js/ListeChoses.js" )(mod);
+// require( "./js/ListeChoses.js" )(mod);

--- a/Liste/V0/package.json
+++ b/Liste/V0/package.json
@@ -26,5 +26,11 @@
     "upath": "^0.1.7",
     "url-loader": "^0.5.7",
     "vinyl-named": "^1.1.0"
+  },
+  "dependencies": {
+    "angular": "^1.5.0",
+    "angular-animate": "^1.5.0",
+    "angular-aria": "^1.5.0",
+    "angular-material": "^1.0.5"
   }
 }

--- a/README.md
+++ b/README.md
@@ -1,1 +1,7 @@
 Les exemples du cours...
+
+Dans les dossiers V0 et V1 faire
+
+1. `npm install`
+2. `gulp`
+3. Ouvrir list.html avec un navigateur web.


### PR DESCRIPTION
Avec la version actuelle des fichiers Gulp de V0, quand on lance gulp on a l'erreur suivante : 

```
[15:51:56] Error in plugin 'gulp-webpack'
Message:
    Path doesn't exist '/home/(…)/Documents_Linux/DCISS/langageEtTechnoWeb2/AngularJs/bshm/Liste/V0/76ece425ab20a1463715.js'
[15:51:56] [object Object]
[15:51:56] webpack is watching for changes
```

Ce pull requests permet de résoudre ce problème. Cependant, quand on lance liste.html avec un navigateur, on n'obtient rien de probant. J'ai encore dû mal comprendre quelque chose…
